### PR TITLE
Remove cyclic tables

### DIFF
--- a/moon/cfc_err_forwarder/error_forwarder.moon
+++ b/moon/cfc_err_forwarder/error_forwarder.moon
@@ -5,16 +5,17 @@ rawset = rawset
 rawget = rawget
 istable = istable
 
-removeCyclic = ( tbl, found={} ) ->
+removeCyclic = (tbl, found={}) ->
     return if found[tbl]
     found[tbl] = true
 
     for k, v in pairs tbl
-        if istable v
-            if found[v]
-                tbl[k] = nil
-            else
-                removeCyclic v, found
+        continue unless istable v
+
+        if found[v]
+            tbl[k] = nil
+        else
+            removeCyclic v, found
 
 class ErrorForwarder
     new: (logger, webhooker, groomInterval) =>


### PR DESCRIPTION
Replaces the empty stack we currently have with a function to strip cyclic errors from it, might cause issues as the stack tables can be insanely huge, 20k lines huge. However, we do need the stack code for webhooker, we're currently only getting the first line of stack traces which just isn't worth much.