### PR TITLE
Replace invalid player with

### DIFF
--- a/moon/cfc_err_forwarder/error_forwarder.moon
+++ b/moon/cfc_err_forwarder/error_forwarder.moon
@@ -37,8 +37,8 @@ class ErrorForwarder
 
     addPlyToObject: (errorStruct, ply) =>
         rawset errorStruct, "player", {
-            playerName: ply\Name!,
-            playerSteamID: ply\SteamID!
+            playerName: ply\Name! or "Invalid Player",
+            playerSteamID: ply\SteamID! or "Invalid Player"
         }
 
         errorStruct
@@ -107,9 +107,11 @@ class ErrorForwarder
         @receiveError isRuntime, fullError, sourceFile, sourceLine, errorString, stack
 
     receiveCLError: (ply, fullError, sourceFile, sourceLine, errorString, stack) =>
-        return unless ply and ply\IsPlayer!
-
-        @logger\info "Received Clientside Lua Error for #{ply\SteamID!} (#{ply\Name!}): #{errorString}"
+        if not ply or ply\IsPlayer!
+            ply = "Invalid player"
+            @logger\info "Received Clientside Lua Error from Invalid Player: #{errorString}"
+        else
+            @logger\info "Received Clientside Lua Error for #{ply\SteamID!} (#{ply\Name!}): #{errorString}"
         @logErrorInfo nil, fullError, sourceFile, sourceLine, errorString, stack
 
         @receiveError isRuntime, fullError, sourceFile, sourceLine, errorString, stack, ply


### PR DESCRIPTION
Currently the dll returns most if not all client errors as non player entities which currently simply gets ignored. However these are the most important errors to track and account for as these are the ones players will get in the game. Seeing who actually got the error is less of an issue compared to seeing the error itself. The webhooker endpoint is able to account for a missing steamid and should work without errors.