### PR TITLE
Add rudementary backup recovery and discord rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This addon will watch for errors, do a little investigation, and send a message 
 ### Some nifty features:
  - :brain: If using source-controlled addons (i.e. git repos in your `addons/` dir), err_forwarder will generate a link to github.com, showing you the exact line that errored
  - :file_cabinet: Tracks Serverside and (optionally) Clientside errors, and can send messages to different channels depending on which realm the errors occurred in
- - :package: Includes configurable batching logic and respects Discord rate limiitng, so it won't spam your error channel
+ - :package: Includes configurable batching logic and respects Discord rate limiting, so it won't spam your error channel
  - :mag_right: Shows you the current values of up to 8 local variables in the stack that threw an error (very useful for debugging!)
- - :floppy_disk: Automatically backs up your unsent errors, making sure you don't lose errors if the server crashes/restarts.
+ - :floppy_disk: Automatically backs up your unsent errors, making it less likely that you lose track of errors if the server crashes/restarts.
 
 ## Requirements
  - [gm_logger](https://github.com/CFC-Servers/gm_logger) _(Optional)_
@@ -27,7 +27,7 @@ This addon will watch for errors, do a little investigation, and send a message 
 
 ## Configuration
  - **`cfc_err_forwarder_dedupe_duration`**: The number of seconds new errors are held before being sent to Discord. Helps de-dupe spammy errors.
- - **`cfc_err_forwarder_backups`**: A boolean indicating whether or not errors should be backed up to a file in case the server crashes or restarts.
+ - **`cfc_err_forwarder_backup`**: A boolean indicating whether or not errors should be backed up to a file in case the server crashes or restarts.
  - **`cfc_err_forwarder_server_webhook`**: The full Discord Webhook URL to send Serverside errors
  - **`cfc_err_forwarder_client_webhook`**: The full Discord Webhook URL to send Clientside errors
  - **`cfc_err_forwarder_client_enabled`**: A boolean indicating whether or not the addon should even track Clientside errors

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ A pure-lua (well, Moonscript) Error tracker for Garry's Mod.
 This addon will watch for errors, do a little investigation, and send a message to a target Discord channel for your review.
 
 ### Some nifty features:
- - 🧠 If using source-controlled addons (i.e. git repos in your `addons/` dir), err_forwarder will generate a link to github.com, showing you the exact line that errored
- - 🪝 Tracks Serverside and (optionally) Clientside errors, and can send messages to different channels depending on which realm the errors occurred in
- - 📦 Includes basic batching logic so it won't spam your error channel
- - 🔎 Shows you the current values of up to 8 local variables in the stack that threw an error (very useful for debugging!)
+ - :brain: If using source-controlled addons (i.e. git repos in your `addons/` dir), err_forwarder will generate a link to github.com, showing you the exact line that errored
+ - :file_cabinet: Tracks Serverside and (optionally) Clientside errors, and can send messages to different channels depending on which realm the errors occurred in
+ - :package: Includes configurable batching logic and respects Discord rate limiitng, so it won't spam your error channel
+ - :mag_right: Shows you the current values of up to 8 local variables in the stack that threw an error (very useful for debugging!)
+ - :floppy_disk: Automatically backs up your unsent errors, making sure you don't lose errors if the server crashes/restarts.
 
 ## Requirements
  - [gm_logger](https://github.com/CFC-Servers/gm_logger) _(Optional)_
@@ -25,7 +26,8 @@ This addon will watch for errors, do a little investigation, and send a message 
 
 
 ## Configuration
- - **`cfc_err_forwarder_interval`**: The interval (in seconds) at which errors are parsed and sent to Discord
+ - **`cfc_err_forwarder_dedupe_duration`**: The number of seconds new errors are held before being sent to Discord. Helps de-dupe spammy errors.
+ - **`cfc_err_forwarder_backups`**: A boolean indicating whether or not errors should be backed up to a file in case the server crashes or restarts.
  - **`cfc_err_forwarder_server_webhook`**: The full Discord Webhook URL to send Serverside errors
  - **`cfc_err_forwarder_client_webhook`**: The full Discord Webhook URL to send Clientside errors
  - **`cfc_err_forwarder_client_enabled`**: A boolean indicating whether or not the addon should even track Clientside errors

--- a/moon/cfc_err_forwarder/discord_interface.moon
+++ b/moon/cfc_err_forwarder/discord_interface.moon
@@ -1,23 +1,125 @@
 Formatter = include "formatter/formatter.lua"
 
-return (config) ->
-    (data, onSuccess, onFailure) ->
-        url = data.isClientside and "client" or "server"
-        url = config.webhook[url]\GetString!
+getRetryAfter = (body, headers) ->
+    body = util.JSONToTable body
+    retryAfter = body and body.retry_after
 
-        body = Formatter data
+    return tonumber(retryAfter) or 5
 
-        failed = (err, ext) -> onFailure "#{err} - #{ext}"
-        success = (status, body) ->
-            if status < 200 or status > 299
-                return failed status, body
-            onSuccess!
-
-        reqwest
-            url: url
-            success: success
-            failed: failed
+-- DiscordInterface tries to send its queue as fast as it can.
+-- After one webook succeeds, it will proceed to send the next one until it runs out or gets rate limited.
+-- Rate limiting is automatically handled.
+class DiscordInterface
+    new: (logger, config) =>
+        @queue = {}
+        @config = config
+        @running = false
+        @retryAfter = nil
+        @logger = logger\scope "DiscordInterface"
+        @saveFile = "cfc_error_forwarder_queue.json"
+        @requestTemplate =
+            timeout: 10
             method: "POST"
+            success: @\onSuccess
+            failed: @\onFailure
             type: "application/json"
             headers: "User-Agent": "CFC Error Forwarder v1"
-            body: util.TableToJSON body
+
+        if @config.backup\GetBool!
+            hook.Add "InitPostEntity", "CFC_ErrForwarder_LoadQueue", -> ProtectedCall @\loadQueue
+
+    -- Saves the current queue to a file so it can be reloaded if the server restarts/changes levels/crashes etc.
+    saveQueue: =>
+        if #@queue == 0
+            if file.Exists @saveFile, "DATA"
+                file.Delete @saveFile
+
+            return
+
+        @logger\info "Saving #{#@queue} unsent errors to queue file. (They will be processed on next server start)"
+        file.Write @saveFile, util.TableToJSON @queue
+
+    loadQueue: =>
+        saved = file.Read @saveFile, "DATA"
+        return unless saved and #saved > 0
+
+        savedQueue = util.JSONToTable saved
+        return unless savedQueue and #savedQueue > 0
+
+        @logger\info "Loaded #{#savedQueue} items from queue file."
+
+        @enqueue item for item in *savedQueue
+        file.Delete @saveFile
+
+    getUrl: (isClientside) =>
+        realm = isClientside and "client" or "server"
+        url = @config.webhook[realm]
+        url and= url\GetString!
+
+        assert url and #url > 0, "[ErrorForwarder] Tried to send a webhook with no URL (#{realm}). Have you set your convars?"
+
+        return url
+
+    sendNext: =>
+        return if @waitUntil and CurTime! < @waitUntil
+
+        -- Stop looping if we're empty
+        item = table.remove @queue, 1
+        if not item
+            -- We clear the saved queue now that we're empty so already-sent errors aren't sent again
+            @saveQueue! if @config.backup\GetBool!
+            @running = false
+            return
+
+        @logger\info "Sending Discord webhook. Queue size: #{#@queue}"
+
+        success, err = pcall ->
+            -- Fill in the rest of the request keys
+            -- TODO: We'll be doing this twice for loaded queue items.
+            table.Merge item, @requestTemplate
+
+            item.url = @getUrl item.isClientside
+            item.isClientside = nil
+            reqwest item
+
+        return if success
+
+        @logger\error "Failed when calling reqwest: #{err}"
+        @sendNext!
+
+    enqueue: (item) =>
+        table.insert @queue, item
+        return if @running
+
+        @running = true
+        @sendNext!
+
+    onRateLimit: (body, headers) =>
+        @retryAfter = getRetryAfter body, headers
+        @logger\warn "Rate limited. Continuing in #{@retryAfter} seconds."
+
+        timer.Create "CFC_ErrForwarder_DiscordRateLimit", @retryAfter, 1, ->
+            @retryAfter = nil
+            @sendNext!
+
+        @saveQueue! if @config.backup\GetBool!
+
+    onSuccess: (code, body, headers) =>
+        if code == 429
+            return @onRateLimit body, headers
+
+        if code >= 400
+            @logger\error "Received failure code on webhook send: Code: #{code} | Body:\n #{body}"
+
+        @sendNext!
+
+    onFailure: (reason) =>
+        @logger\error "Failed to send webhook: #{reason}"
+        @sendNext!
+
+    Send: (data) =>
+        @enqueue
+            isClientside: data.isClientside
+            body: util.TableToJSON Formatter data
+
+return DiscordInterface

--- a/moon/cfc_err_forwarder/error_forwarder.moon
+++ b/moon/cfc_err_forwarder/error_forwarder.moon
@@ -1,97 +1,40 @@
 import Count from table
 
-osTime = os.time
 rawset = rawset
 rawget = rawget
-istable = istable
+os_time = os.time
 
-pretty = include "cfc_err_forwarder/formatter/pretty_values.lua"
+:stripStack, :saveLocals = include "cfc_err_forwarder/helpers.lua"
+discordBuilder = include "cfc_err_forwarder/discord_interface.lua"
 
-removeCyclic = (tbl, found={}) ->
-    return if found[tbl]
-    found[tbl] = true
-
-    for k, v in pairs tbl
-        continue unless istable v
-
-        if found[v]
-            print "Found cyclic table, key: #{k} | value: #{v} | table: #{tbl}"
-            tbl[k] = nil
-        else
-            removeCyclic v, found
-
-stripStack = (tbl) ->
-    for _, stackObj in pairs tbl
-        stackObj.upvalues = nil
-        stackObj.activelines = nil
-
-stringTable = (tbl) ->
-    oneline = table.Count(tbl) == 1
-
-    str = "{"
-    str ..= "\n" unless oneline
-
-    count = 0
-    for k, v in pairs tbl
-        break if count >= 5
-
-        str ..= "  #{k} = #{pretty v}"
-        str ..= oneline and " " or "\n"
-
-        count += 1
-
-    str ..= "}"
-
-    str
-
-saveLocals = (stack) ->
-    for _, stackObj in pairs stack
-        locals = stackObj.locals
-        continue unless locals
-
-        newLocals = {}
-        for name, value in pairs locals
-            if istable value
-                newLocals[name] = stringTable value
-            else
-                newLocals[name] = pretty value
-
-                newLocal = newLocals[name]
-                if #newLocal > 125
-                    newLocals[name] = "#{string.Left newLocal, 122}..."
-
-        stackObj.locals = newLocals
-
-return class ErrorForwarder
-    new: (logger, discord, config) =>
-        @logger = logger
-        @discord = discord
-        @config = config
+class ErrorForwarder
+    new: (logger, config) =>
         @queue = {}
+        @config = config
+        @logger = logger
+        @discord = discordBuilder logger, config
+        @timerName = "CFC_ErrorForwarderQueue"
 
-    countQueue: => Count @queue
+        @startTimer!
+
+    startTimer: () =>
+        timer.Create @timerName, @config.dedupeDuration\GetInt! or 60, 0, ->
+            ProtectedCall @\groomQueue
+
+    adjustTimer: (interval) =>
+        timer.Adjust @timerName, tonumber interval
 
     errorIsQueued: (fullError) => rawget(@queue, fullError) ~= nil
 
-    addPlyToObject: (errorStruct, ply) =>
-        rawset errorStruct, "player", {
-            playerName: ply\Name!,
-            playerSteamID: ply\SteamID!
-        }
-
-        errorStruct
-
     queueError: (isRuntime, fullError, sourceFile, sourceLine, errorString, stack, ply) =>
         count = 1
-        occurredAt = osTime!
-        isClientside = ply ~= nil
-        locals = saveLocals stack
+        occurredAt = os_time!
 
-        local plyName
-        local plySteamID
-        if ply
-            plyName = ply\Nick!
-            plySteamID = ply\SteamID!
+        saveLocals stack
+        stripStack stack
+
+        isClientside = ply ~= nil
+        hasPly = isClientside and ply\IsValid!
 
         newError = {
             :count
@@ -103,54 +46,31 @@ return class ErrorForwarder
             :sourceLine
             :stack
             :isClientside
-            :ply
-            :plyName
-            :plySteamID
-            reportInterval: @config.groomInterval\GetInt!
+            :hasPly
         }
 
-        if isClientside
-            newError = @addPlyToObject newError, ply
+        if hasPly
+            newError.plyName = ply\Nick!
+            newError.plySteamID = ply\SteamID!
 
         @logger\debug "Inserting error into queue: '#{fullError}'"
 
         rawset @queue, fullError, newError
 
-    unqueueError: (fullError) =>
-        thisErr = rawget @queue, fullError
-
-        if thisErr
-            for k in pairs thisErr
-                rawset thisErr, k, nil
-
-        rawset @queue, fullError, nil
-
     incrementError: (fullError) =>
-        thisErr = rawget @queue, fullError
-        count = rawget thisErr, "count"
-
-        rawset thisErr, "count", count + 1
-        rawset thisErr, "occurredAt", osTime!
+        with rawget @queue, fullError
+            .count += 1
+            .occurredAt = os_time!
 
     receiveError: (isRuntime, fullError, sourceFile, sourceLine, errorString, stack, ply) =>
         if @errorIsQueued fullError
             return @incrementError fullError
 
         @queueError isRuntime, fullError, sourceFile, sourceLine, errorString, stack, ply
-
-    logErrorInfo: (isRuntime, fullError, sourceFile, sourceLine, errorString, stack) =>
-        debug = @logger\debug
-
-        debug "Is Runtime: #{isRuntime}"
-        debug "Full Error: #{fullError}"
-        debug "Source File: #{sourceFile}"
-        debug "Source Line: #{sourceLine}"
-        debug "Error String: #{errorString}"
+        return nil
 
     receiveSVError: (isRuntime, fullError, sourceFile, sourceLine, errorString, stack) =>
         @logger\debug "Received Serverside Lua Error: #{errorString}"
-        @logErrorInfo isRuntime, fullError, sourceFile, sourceLine, errorString, stack
-
         @receiveError isRuntime, fullError, sourceFile, sourceLine, errorString, stack
 
     receiveCLError: (ply, fullError, sourceFile, sourceLine, errorString, stack) =>
@@ -158,49 +78,22 @@ return class ErrorForwarder
         return unless @config.clientEnabled\GetBool!
 
         @logger\debug "Received Clientside Lua Error for #{ply\SteamID!} (#{ply\Name!}): #{errorString}"
-        @logErrorInfo true, fullError, sourceFile, sourceLine, errorString, stack
 
         @receiveError true, fullError, sourceFile, sourceLine, errorString, stack, ply
 
-    -- TODO: Remove this stupid thing andc all stripStack directly
-    cleanStruct: (errorStruct) =>
-        stripStack errorStruct.stack
-        return errorStruct
-
-    forwardError: (errorStruct, onSuccess, onFailure) =>
-        @logger\debug "Sending error object.."
-        self.discord errorStruct, onSuccess, onFailure
-
     forwardErrors: =>
-        for errorString, data in pairs @queue
-            @logger\debug "Processing queued error: #{errorString}"
+        for errorString, errorData in pairs @queue
+            @logger\debug "Sending queued error to Discord: #{errorString}"
+            @discord\Send errorData
 
-            errorData = @cleanStruct data
-
-            onSuccess = -> @onSuccess errorString
-            onFailure = (failure) -> @onFailure errorString, failure, errorData
-
-            success, err = pcall ->
-                @forwardError errorData, onSuccess, onFailure
-
-            continue if success
-
-            onFailure err
+        table.Empty @queue
 
     groomQueue: =>
-        count = @countQueue!
+        count = Count @queue
         return if count == 0
 
         @logger\debug "Grooming Error Queue of size: #{count}"
         @forwardErrors!
 
-    onSuccess: (fullError) =>
-        @logger\debug "Successfully sent error", fullError
 
-        @unqueueError fullError
-
-    onFailure: (fullError, failure, errorData) =>
-        @logger\error "Failed to send error!", failure
-        @unqueueError fullError
-        print util.TableToJSON failedErrorData: errorData
-
+return ErrorForwarder

--- a/moon/cfc_err_forwarder/formatter/formatter.moon
+++ b/moon/cfc_err_forwarder/formatter/formatter.moon
@@ -35,8 +35,8 @@ nonil = (t) -> [v for v in *t when v ~= nil]
                     with l = locals data
                         return { name: "Locals", value: code truncate(l), "m"  } if l
 
-                    with {:ply, :plyName, :plySteamID} = data
-                        return { name: "Player", value: bold "#{plyName} ( #{steamIDLink plySteamID} )" } if ply
+                    with {:hasPly, :plyName, :plySteamID} = data
+                        return { name: "Player", value: bold "#{plyName} ( #{steamIDLink plySteamID} )" } if hasPly
                         return nil
 
                     {

--- a/moon/cfc_err_forwarder/helpers.moon
+++ b/moon/cfc_err_forwarder/helpers.moon
@@ -1,0 +1,46 @@
+pretty = include "cfc_err_forwarder/formatter/pretty_values.lua"
+
+stripStack = (tbl) ->
+    for _, stackObj in pairs tbl
+        stackObj.upvalues = nil
+        stackObj.activelines = nil
+
+stringTable = (tbl) ->
+    oneline = table.Count(tbl) == 1
+
+    str = "{"
+    str ..= "\n" unless oneline
+
+    count = 0
+    for k, v in pairs tbl
+        break if count >= 5
+
+        str ..= "  #{k} = #{pretty v}"
+        str ..= oneline and " " or "\n"
+
+        count += 1
+
+    str ..= "}"
+
+    str
+
+
+saveLocals = (stack) ->
+    for _, stackObj in pairs stack
+        locals = stackObj.locals
+        continue unless locals
+
+        newLocals = {}
+        for name, value in pairs locals
+            if istable value
+                newLocals[name] = stringTable value
+            else
+                newLocals[name] = pretty value
+
+                newLocal = newLocals[name]
+                if #newLocal > 125
+                    newLocals[name] = "#{string.Left newLocal, 122}..."
+
+        stackObj.locals = newLocals
+
+return { :stripStack, :saveLocals }


### PR DESCRIPTION
### This PR accomplishes two things:
 1. Basic backup and recovery of the error queue, making it less likely that servers will lose errors in the event of a crash or restart (not perfect though).
 2. Fully respect Discord rate limits

_(Addresses #30)_

### Some notes:
#### **`cfc_err_forwarder_interval`** has been changed to **`cfc_err_forwarder_dedupe_duration`**. The setting is similar, but now has a more focused purpose, justifying a rename.

#### ErrorForwarder will not retry failed webhooks, it will simply log the failure and move on. My thinking is that servers typically have a reliable connection _(the one exception being a message that's too long)_, so any issue causing requests to fail would likely cause _all_ requests to fail. To that end, I'm not sure how useful retries will actually be.