### PR TITLE
Use basegame full error

### DIFF
--- a/moon/cfc_err_forwarder/plain_receiver.moon
+++ b/moon/cfc_err_forwarder/plain_receiver.moon
@@ -14,15 +14,19 @@ convertPlainStack = (stack) ->
 
     return newStack
 
-getErrorStringFromFull = (fullError) ->
-    errStringStart = string.find fullError, ": "
+getErrorStringFromFull = (fullError, addontitle) ->
+    error_text = str
+    error_text = error_text.gsub("\t", " ".rep 12) -- Ew
+    
+    for i, t in *stack
+      t.Function = "unknown" unless t.Function and t.Function != ""
+      error_text ..= "\n" .. "    ".rep(i) .. i .. ". " .. t.Function .. " - " .. t.File .. ":" .. t.Line
+    
+    return "[" .. addontitle .. "] " .. error_text
 
-    return fullError unless errStringStart
-    return string.sub fullError, errStringStart + 2
-
-hook.Add "OnLuaError", "CFC_ServerErrorForwarder", (fullError, realm, stack) ->
+hook.Add "OnLuaError", "CFC_ServerErrorForwarder", (fullError, realm, stack, addontitle) ->
     stack = convertPlainStack stack
-    errorString = getErrorStringFromFull fullError
+    errorString = getErrorStringFromFull fullError, addontitle
 
     firstLevel = stack[1]
     sourceFile = firstLevel and firstLevel.source


### PR DESCRIPTION
https://github.com/Facepunch/garrysmod/blob/3f30cc7e95a48b0106b4d53c997cb493eaf6844a/garrysmod/lua/menu/problems/problems.lua#L113-L151

Converts the errors to look like you'd see in game
example:
```
[luapad] addons/luapad/lua/luapad/shared/code_execution.lua:75: x
    1. error - [C]:-1
        2. error - addons/luapad/lua/luapad/shared/code_execution.lua:75
            3. unknown - Luapad[STEAM_0:0:55976004]Redox.lua:1
```