### PR TITLE
Use 0 tick timer for hibernation runs

### DIFF
--- a/lua/cfc_err_forwarder/error_forwarder.lua
+++ b/lua/cfc_err_forwarder/error_forwarder.lua
@@ -90,11 +90,11 @@ function Forwarder:getInterval()
 end
 
 function Forwarder:startTimer()
-    local nextRun = os_Time() + self:getInterval()
+    local lastRun = os_Time()
     timer.Create( queueName, 0, 0, function() -- 0 tick timer so it still runs during hibernation
         ProtectedCall( function()
-            if os_Time() < nextRun then return end
-            nextRun = os_Time() + self:getInterval()
+            if os_Time() - lastRun < self:getInterval() then return end
+            lastRun = os_Time()
 
             self:groomQueue()
         end )

--- a/lua/cfc_err_forwarder/error_forwarder.lua
+++ b/lua/cfc_err_forwarder/error_forwarder.lua
@@ -85,9 +85,17 @@ function Forwarder:errorIsQueued( fullError )
     return self.queue[fullError]
 end
 
+function Forwarder:getInterval()
+    return Config.groomInterval:GetInt() or 60
+end
+
 function Forwarder:startTimer()
-    timer.Create( queueName, Config.groomInterval:GetInt() or 60, 0, function()
+    local nextRun = os_Time() + self:getInterval()
+    timer.Create( queueName, 0, 0, function() -- 0 tick timer so it still runs during hibernation
         ProtectedCall( function()
+            if os_Time() < nextRun then return end
+            nextRun = os_Time() + self:getInterval()
+
             self:groomQueue()
         end )
     end )

--- a/lua/cfc_err_forwarder/error_forwarder.lua
+++ b/lua/cfc_err_forwarder/error_forwarder.lua
@@ -101,10 +101,6 @@ function Forwarder:startTimer()
     end )
 end
 
-function Forwarder:adjustTimer( interval )
-    timer.Adjust( queueName, tonumber( interval ) )
-end
-
 function Forwarder:incrementError( fullError )
     local item = self.queue[fullError]
     item.count = item.count + 1

--- a/lua/cfc_err_forwarder/init.lua
+++ b/lua/cfc_err_forwarder/init.lua
@@ -49,10 +49,6 @@ include( "cfc_err_forwarder/branch.lua" )
 local Discord = EF.Discord
 local Forwarder = EF.Forwarder
 
-cvars.AddChangeCallback( Config.groomInterval:GetName(), function( _, _, new )
-    Forwarder:adjustTimer( new )
-end, "UpdateTimer" )
-
 cvars.AddChangeCallback( Config.backup:GetName(), function( _, _, new )
     if new ~= "1" then return end
     EF.Discord:LoadQueue()


### PR DESCRIPTION
Currently if there's errors in the queue and everyone leaves the server wont send the errors due to hibernation. Happens if there's a bunch of errors and the queue. Or for example if a error happens in PlayerDisconnected when they're the last to leave.