### PR TITLE
Basegame cl errors

### DIFF
--- a/lua/autorun/cfc_err_fwd.lua
+++ b/lua/autorun/cfc_err_fwd.lua
@@ -1,5 +1,11 @@
-ErrorForwarder = {}
+ErrorForwarder = ErrorForwarder or {}
+
+if SERVER then
+    AddCSLuaFile( "cfc_err_forwarder/branch.lua" )
+    AddCSLuaFile( "cfc_err_forwarder/client/forwarder.lua" )
+end
 
 if CLIENT then
     include( "cfc_err_forwarder/branch.lua" )
+    include( "cfc_err_forwarder/client/forwarder.lua" )
 end

--- a/lua/cfc_err_forwarder/client/forwarder.lua
+++ b/lua/cfc_err_forwarder/client/forwarder.lua
@@ -29,7 +29,7 @@ local function createTimer()
         for _, traceLevel in ipairs( stack ) do
             net.WriteString( traceLevel.File or "" )
             net.WriteString( traceLevel.Function or "" )
-            net.WriteUInt( traceLevel.Line or 0, 16 )
+            net.WriteInt( traceLevel.Line or 0, 16 )
         end
 
         net.SendToServer()

--- a/lua/cfc_err_forwarder/client/forwarder.lua
+++ b/lua/cfc_err_forwarder/client/forwarder.lua
@@ -16,7 +16,7 @@ end )
 
 local function createTimer()
     ErrorForwarder.CreatedClientErrorTimer = true
-    timer.Create( "CFC_ClientErrorForwarder", 5, 0, function()
+    timer.Create( "CFC_ClientErrorForwarder", 6, 0, function()
         if #ErrorForwarder.ClientErrorQueue == 0 then return end
 
         local errorData = table.remove( ErrorForwarder.ClientErrorQueue, 1 )

--- a/lua/cfc_err_forwarder/client/forwarder.lua
+++ b/lua/cfc_err_forwarder/client/forwarder.lua
@@ -1,0 +1,46 @@
+if util.NetworkStringToID( "cfc_errorforwarder_clienterror" ) == 0 then return end -- Server doesn't have clientside error forwarding enabled.
+
+ErrorForwarder.ClientErrorQueue = ErrorForwarder.ClientErrorQueue or {}
+ErrorForwarder.ClientErrorsLogged = ErrorForwarder.ClientErrorsLogged or {}
+
+hook.Add( "OnLuaError", "CFC_RuntimeErrorForwarder", function( err, _, stack )
+    local errorHash = util.CRC( err .. util.TableToJSON( stack ) )
+    if ErrorForwarder.ClientErrorsLogged[errorHash] then return end
+    ErrorForwarder.ClientErrorsLogged[errorHash] = true
+
+    table.insert( ErrorForwarder.ClientErrorQueue, {
+        err = err,
+        stack = stack,
+    } )
+end )
+
+local function createTimer()
+    ErrorForwarder.CreatedClientErrorTimer = true
+    timer.Create( "CFC_ClientErrorForwarder", 5, 0, function()
+        if #ErrorForwarder.ClientErrorQueue == 0 then return end
+
+        local errorData = table.remove( ErrorForwarder.ClientErrorQueue, 1 )
+        local err = errorData.err
+        local stack = errorData.stack
+
+        net.Start( "cfc_errorforwarder_clienterror" )
+        net.WriteString( err )
+        net.WriteUInt( #stack, 4 )
+        for _, traceLevel in ipairs( stack ) do
+            net.WriteString( traceLevel.File or "" )
+            net.WriteString( traceLevel.Function or "" )
+            net.WriteUInt( traceLevel.Line or 0, 16 )
+        end
+
+        net.SendToServer()
+    end )
+end
+
+if ErrorForwarder.CreatedClientErrorTimer then -- Autorefresh
+    createTimer()
+end
+
+hook.Add( "InitPostEntity", "CFC_ClientErrorForwarder", function()
+    hook.Remove( "InitPostEntity", "CFC_ClientErrorForwarder" )
+    createTimer()
+end )

--- a/lua/cfc_err_forwarder/init.lua
+++ b/lua/cfc_err_forwarder/init.lua
@@ -133,22 +133,25 @@ do -- Base game error hooks
             local err = net.ReadString()
             local stackSize = net.ReadUInt( 4 )
             local stack = {}
-            for i = 1, stackSize do
-                local file = net.ReadString()
+            for _ = 1, stackSize do
+                local fileName = net.ReadString()
                 local funcName = net.ReadString()
-                local line = net.ReadUInt( 16 )
+                local line = net.ReadInt( 16 )
 
-                stack[i] = {
-                    File = file,
+                table.insert( stack, {
+                    File = fileName,
                     Function = funcName,
                     Line = line,
-                }
+                } )
             end
 
+            if #stack == 0 then return end
+
+            local newStack = convertStack( stack --[[@as GmodOnLuaErrorStack]] )
             local firstEntry = stack[1]
             if not firstEntry then return end
 
-            receiver( ply, err, firstEntry.File, firstEntry.Line, err, stack )
+            receiver( ply, err, firstEntry.File, firstEntry.Line, err, newStack )
         end )
     end
 end

--- a/lua/cfc_err_forwarder/init.lua
+++ b/lua/cfc_err_forwarder/init.lua
@@ -86,7 +86,7 @@ local function receiver( plyOrIsRuntime, fullError, sourceFile, sourceLine, erro
     Forwarder:QueueError( luaError )
 end
 
-do
+do -- Base game error hooks
     --- Converts a stack from the base game OnLuaError and converts it to the standard debug stackinfo
     --- @param luaHookStack GmodOnLuaErrorStack
     local function convertStack( luaHookStack )
@@ -112,13 +112,45 @@ do
 
     hook.Add( "OnLuaError", "CFC_RuntimeErrorForwarder", function( err, _, stack )
         -- Skip this if we're using gm_luaerror and are configured to use it
-        if luaerror and not Config.useLuaErrorBinary:GetBool() == true then return end
+        if luaerror and Config.useLuaErrorBinary:GetBool() then return end
 
         local newStack = convertStack( stack --[[@as GmodOnLuaErrorStack]] )
 
         local firstEntry = stack[1]
         receiver( true, err, firstEntry.File, firstEntry.Line, err, newStack )
     end )
+
+    -- Client error networking logic when gm_luaerror isn't installed
+    if not luaerror then
+        util.AddNetworkString( "cfc_errorforwarder_clienterror" )
+
+        net.Receive( "cfc_errorforwarder_clienterror", function( _, ply )
+            if not Config.clientEnabled:GetBool() then return end
+
+            if ply.ErrorForwarder_LastReceiveTime and ply.ErrorForwarder_LastReceiveTime > os_time() - 5 then return end
+            ply.ErrorForwarder_LastReceiveTime = os_time()
+
+            local err = net.ReadString()
+            local stackSize = net.ReadUInt( 4 )
+            local stack = {}
+            for i = 1, stackSize do
+                local file = net.ReadString()
+                local funcName = net.ReadString()
+                local line = net.ReadUInt( 16 )
+
+                stack[i] = {
+                    File = file,
+                    Function = funcName,
+                    Line = line,
+                }
+            end
+
+            local firstEntry = stack[1]
+            if not firstEntry then return end
+
+            receiver( ply, err, firstEntry.File, firstEntry.Line, err, stack )
+        end )
+    end
 end
 
 -- gm_luaerror hooks


### PR DESCRIPTION
Networks basegame cl errors using the OnLuaError hook, sends the errors only once and has ratelimiting, same limit as the basegame error limit which seems to be a leakybucket of 5 with a 1s regen

`lua_run_cl error("testerrorontheclient!")`

![image](https://github.com/user-attachments/assets/56382cf2-f133-4a35-a697-549940b7398a)
